### PR TITLE
Add ICRC-28 and ICRC-10 support to enable public account.

### DIFF
--- a/miner-v2/miner.did
+++ b/miner-v2/miner.did
@@ -21,4 +21,6 @@ service : (principal) -> {
   get_statistics_v2 : () -> (StatsV2) query;
   push_challenge : (blob, nat64) -> ();
   update_miner_settings : (MinerSettings) -> ();
+  icrc10_supported_standards : () -> (vec record { name : text; url : text }) query;
+  icrc28_trusted_origins : () -> (record { trusted_origins: vec text });
 }

--- a/miner-v2/src/main.rs
+++ b/miner-v2/src/main.rs
@@ -73,6 +73,41 @@ fn get_state() -> State {
     read_state(|s| s.clone())
 }
 
+#[derive(CandidType)]
+struct Icrc28TrustedOriginsResponse {
+    pub trusted_origins: Vec<String>
+}
+
+#[update]
+fn icrc28_trusted_origins() -> Icrc28TrustedOriginsResponse {
+    let trusted_origins = vec![
+        String::from("https://bob.fun"),
+        String::from("https://ywiuf-vaaaa-aaaal-qjumq-cai.icp0.io")
+    ];
+
+    return Icrc28TrustedOriginsResponse { trusted_origins }
+}
+
+#[derive(CandidType)]
+struct Icrc10SupportedStandard {
+    pub url: String,
+    pub name: String,
+}
+
+#[query]
+fn icrc10_supported_standards() -> Vec<Icrc10SupportedStandard> {
+    vec![
+        Icrc10SupportedStandard {
+            url: "https://github.com/dfinity/ICRC/blob/main/ICRCs/ICRC-10/ICRC-10.md".to_string(),
+            name: "ICRC-10".to_string(),
+        },
+        Icrc10SupportedStandard {
+            url: "https://github.com/dfinity/wg-identity-authentication/blob/main/topics/icrc_28_trusted_origins.md".to_string(),
+            name: "ICRC-28".to_string(),
+        },
+    ]
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/minter-v2/bob.did
+++ b/minter-v2/bob.did
@@ -46,4 +46,6 @@ service : () -> {
   spawn_miner : (nat64) -> (Result_1);
   submit_burned_cycles : (nat64) -> (Result);
   upgrade_miner : (principal) -> (Result);
+  icrc10_supported_standards : () -> (vec record { name : text; url : text }) query;
+  icrc28_trusted_origins : () -> (record { trusted_origins: vec text });
 }

--- a/minter-v2/src/main.rs
+++ b/minter-v2/src/main.rs
@@ -364,6 +364,41 @@ fn get_miners(of: Principal) -> Vec<Miner> {
     })
 }
 
+#[derive(CandidType)]
+struct Icrc28TrustedOriginsResponse {
+    pub trusted_origins: Vec<String>
+}
+
+#[update]
+fn icrc28_trusted_origins() -> Icrc28TrustedOriginsResponse {
+    let trusted_origins = vec![
+        String::from("https://bob.fun"),
+        String::from("https://ywiuf-vaaaa-aaaal-qjumq-cai.icp0.io")
+    ];
+
+    return Icrc28TrustedOriginsResponse { trusted_origins }
+}
+
+#[derive(CandidType)]
+struct Icrc10SupportedStandard {
+    pub url: String,
+    pub name: String,
+}
+
+#[query]
+fn icrc10_supported_standards() -> Vec<Icrc10SupportedStandard> {
+    vec![
+        Icrc10SupportedStandard {
+            url: "https://github.com/dfinity/ICRC/blob/main/ICRCs/ICRC-10/ICRC-10.md".to_string(),
+            name: "ICRC-10".to_string(),
+        },
+        Icrc10SupportedStandard {
+            url: "https://github.com/dfinity/wg-identity-authentication/blob/main/topics/icrc_28_trusted_origins.md".to_string(),
+            name: "ICRC-28".to_string(),
+        },
+    ]
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Hey there from IdentityLabs!

We love how you've integrated identityKit and are making great use of the NFID wallet. We noticed that you’re relying heavily on app-specific accounts, which create different principals for each app. While that works, we believe having a global account, a single principal across all apps in a network, is a game-changer. That’s why we decided to add this feature to one of the most popular projects on IC - yours!

The changes are on the backend side, totally safe to merge, and won’t cause any issues on their own. This feature also needs a few updates on the frontend. I couldn’t find your frontend code, so I wanted to share what needs to be done. Here's a guide to help: https://docs.identitykit.xyz/getting-started/installation#wrap-provider. I’m guessing you already have a similar setup in your code, so it should just be a matter of updating the targets:

```
<IdentityKitProvider
   authType={IdentityKitAuthType.DELEGATION}
   signerClientOptions={{
      targets=["6lnhz-oaaaa-aaaas-aabkq-cai", "mr6ee-jaaaa-aaaas-aaciq-cai"]
   }}>
   <YourApp />
</IdentityKitProvider>
```

We’d absolutely love to see public accounts available in your app and hear how the integration goes!